### PR TITLE
set devfile's schemaVersion to 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: nodejs-web-app
 components:


### PR DESCRIPTION
Updates devfile's schemaVersion to 2.2.2

Related issue: https://github.com/eclipse/che/issues/21985


![screenshot-devspaces apps sandbox-stage gb17 p1 openshiftapps com-2024 02 01-16_00_41](https://github.com/devspaces-samples/web-nodejs-sample/assets/1271546/ac12d932-e318-450e-b64e-d6e3aae52d26)

